### PR TITLE
Citing (and license)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: FreeEnergyNetworkAnalysis
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Antonia
+    family-names: Mey
+  - given-names: Paolo
+    family-names: Tosco
+  - given-names: Scheen
+    family-names: Jenke    
+  - given-names: Julien
+    family-names: Michel
+license: CC-BY-SA-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,4 +16,6 @@ authors:
     family-names: Jenke    
   - given-names: Julien
     family-names: Michel
+repository-code: >-
+  https://github.com/michellab/freenrgworkflows/tree/devel
 license: CC-BY-SA-2.0

--- a/README.md
+++ b/README.md
@@ -49,3 +49,6 @@ summary_r1.csv is an collated output of analyse_freenrg mbar from [SOMD](https:/
 ## Questions, Comments, Docs
 
 Contact one of the authors.
+
+## License
+This work is licensed under [Attribution-ShareAlike 2.0 Generic (CC BY-SA 2.0)](https://creativecommons.org/licenses/by-sa/2.0/).


### PR DESCRIPTION
Added a CITATION.cff which makes the repo citable, see https://citation-file-format.github.io/. 

Given the file setup currently, exporting the bibtex gives:
`@software{Mey_FreeEnergyNetworkAnalysis,
author = {Mey, Antonia and Tosco, Paolo and Jenke, Scheen and Michel, Julien},
license = {CC-BY-SA-2.0},
title = {{FreeEnergyNetworkAnalysis}},
url = {https://github.com/michellab/freenrgworkflows/tree/devel}
}`

and the reference (RSC styling template) gives:
![image](https://user-images.githubusercontent.com/43140137/162444371-f1b45206-977b-4f99-97ec-dbcb4d661d20.png)
.. neat!

Also added a license entry in readme.md (links to CC-BY-SA).