### PR TITLE
changes for workshop so that the network can be analysed

### DIFF
--- a/networkanalysis/networkanalysis.py
+++ b/networkanalysis/networkanalysis.py
@@ -129,10 +129,10 @@ class NetworkAnalyser(object):
         self._compoundList = list(graph.nodes())
         self._compoundList.sort()
         if len(largest) < len(self._compoundList):
-            warnings.warn('Provided network is disconnected. Doing analysis on subgraph.')
+            warnings.warn('Provided network is disconnected. Doing analysis on subgraph.') # FIXME
 
-        # We only do the analysis for the largest connected set of nodes
-        for node in largest:
+        # Doing analysis for all the nodes
+        for node in self._compoundList:
 
             if node not in self._ddG_edges:
                 self._ddG_edges[node] = {}


### PR DESCRIPTION
Hello! For the [September CCPBioSim BSS workshop](https://github.com/michellab/bssccpbiosim2022), when using freenrgworkflows as is, it is not able to analyse the provided network for the following [results files](https://github.com/michellab/bssccpbiosim2022/tree/main/relative_binding_free_energies/answers/example_output_analysis) (results_X.csv).
![image](https://user-images.githubusercontent.com/83006586/190406150-6b590ef6-bb54-4093-8884-400c090c4f9f.png)

The following warning shows up:
`Provided network is disconnected. Doing analysis on subgraph.`
However, the network should have enough edges I think.

As a result of this, after the first file is added, once the second set of data is added using the following code:
```
nA = networkanalysis.NetworkAnalyser()
first_file = False
for file_name in results_files:
    if first_file is False:
        nA.read_perturbations_pandas(file_name, comments='#')
        first_file = True
    else:
        nA.add_data_to_graph_pandas(file_name)

computed_relative_DDGs = nA.freeEnergyInKcal
```
the following error shows up:
```
--> 239 self._ddG_edges[u][v] = mean_edge
    240 self._weights[u][v] = prop_error
    242 averaged_edge_counter += 1
KeyError: 'ejm_55'
```
I realised this is because the edge for this ligand does not exist, as when the first file was loaded it used [largest](https://github.com/michellab/freenrgworkflows/blob/af7c8638beafdd4830465fdc36883a3957a353be/networkanalysis/networkanalysis.py#L135):
```
        # We want to know what the largest component is, so we know if we may not be able to estimate certain free
        # energies
        largest = max(nx.strongly_connected_components(graph), key=len)

        # populate compound list:
        self._compoundList = list(graph.nodes())
        self._compoundList.sort()
        if len(largest) < len(self._compoundList):
            warnings.warn('Provided network is disconnected. Doing analysis on subgraph.')

        # We only do the analysis for the largest connected set of nodes
        for node in largest:
```
when analysis was carried out for the node in largest, only about four edges were added to the network in `self._ddG_edges`.
Changing this to:
```
for node in self._compoundList:
```
as has been done for the copy of freenergworkflows in the workshop allows full analysis for all edges to be carried out. 

I was wondering if in this case only doing analysis for the largest connected set of nodes is robust to be able to handle when networks such as this one are passed in?